### PR TITLE
Fixed RWP display bug and Standings sorting

### DIFF
--- a/components/franchises/teams/TeamPanel.tsx
+++ b/components/franchises/teams/TeamPanel.tsx
@@ -116,7 +116,7 @@ function TeamStats({ stats, rank, isApexRank }: { stats; rank; isApexRank }) {
     { label: "RANK: ", value: rank >= 0 ? rank + 1 : "N/A" },
     { label: "W: ", value: stats?.wins || 0 },
     { label: "L: ", value: stats?.losses || 0 },
-    { label: "RWP: ", value: `${stats?.rwp || 0}%` },
+    { label: "RWP: ", value: `${(stats?.rwp *100).toFixed(0) || 0}%` },
   ];
 
   return (

--- a/lib/queries/standings/standings.ts
+++ b/lib/queries/standings/standings.ts
@@ -81,17 +81,19 @@ export async function getFranchiseStandings(
 }
 
 function compareStandings(left: TStandingProps, right: TStandingProps): number {
-  // 1) compare RWP
-  if (right.rwp > left.rwp) return 1;
-  if (right.rwp < left.rwp) return -1;
+  
 
-  // 2) then wins (more is good!)
+  // 1) compare wins (more is good!)
   if (right.wins > left.wins) return 1;
   if (right.wins < left.wins) return -1;
 
-  // 3) then losses (less is good!)
-  if (left.losses < right.losses) return 1;
-  if (left.losses > right.losses) return -1;
+  // 2) then losses (less is good!)
+  if (left.losses < right.losses) return -1;
+  if (left.losses > right.losses) return 1;
+
+  // 3) then compare RWP (higher is better!)
+  if (right.rwp > left.rwp) return 1;
+  if (right.rwp < left.rwp) return -1;
 
   // 4) alphabetical (if it somehow gets to this...)
   return left.franchiseSlug.localeCompare(right.franchiseSlug);


### PR DESCRIPTION
Fixed RWP display in Franchises to correctly display a percentage. Standings are now sorted by:
Number of wins > number of losses > RWP instead of RWP > Number of wins > number of losses