### PR TITLE
fix /player back-nav loop

### DIFF
--- a/app/franchises/[slug]/page.tsx
+++ b/app/franchises/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 import { toTailwindCustomHexCode } from "@/lib/common/utils";
 import Image from "next/image";
 import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getUserTier } from "@/lib/queries/user/user";
@@ -24,6 +25,7 @@ import { prisma } from "@/lib/prisma";
 
 type Props = {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -34,24 +36,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
-  const { slug } = await params;
-  const currentSeason = await getSeasonCached();
-  const userTier = await getUserTier();
+export default async function Page({ params, searchParams }: Props) {
+  const [{ slug }, sp, currentSeason, userTier] = await Promise.all([
+    params,
+    searchParams,
+    getSeasonCached(),
+    getUserTier(),
+  ]);
 
   const res = await getFranchiseDetailsBySlugCached(
     String(slug).toLocaleLowerCase(),
     currentSeason,
   );
+  if (!res) notFound();
 
-  let franchiseInfo;
-  if (res) {
-    franchiseInfo = res;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const franchiseInfo: any = res;
 
   const primary = toTailwindCustomHexCode(franchiseInfo!.Brand!.colorPrimary);
   const secondary = toTailwindCustomHexCode(
@@ -67,6 +67,15 @@ export default async function Page({
       userTier,
     );
     defaultQuery = franchiseHasTier ? userTier : "";
+  }
+
+  if (activeTeams.length > 0) {
+    const validTeams = new Set(activeTeams.map((t) => t.query.toLowerCase()));
+    const teamOk = typeof sp.team === "string" && validTeams.has(sp.team);
+    if (!teamOk) {
+      const defaultTeam = (defaultQuery || activeTeams[0].query).toLowerCase();
+      redirect(`/franchises/${slug}?team=${defaultTeam}`);
+    }
   }
 
   return (
@@ -116,13 +125,19 @@ export default async function Page({
           </div>
         </div>
         <div className="xl:max-w-5xl flex flex-col gap-5">
-          <Suspense fallback={<TeamPanelSkeleton />}>
-            <HorizontalTab
-              tabElements={activeTeams}
-              params="team"
-              defaultQuery={defaultQuery}
-            />
-          </Suspense>
+          {activeTeams.length === 0 ? (
+            <div className="text-center italic text-vdcGrey dark:text-vdcWhite py-10">
+              No active teams for this franchise.
+            </div>
+          ) : (
+            <Suspense fallback={<TeamPanelSkeleton />}>
+              <HorizontalTab
+                tabElements={activeTeams}
+                params="team"
+                defaultQuery={defaultQuery}
+              />
+            </Suspense>
+          )}
         </div>
       </div>
     </div>

--- a/app/player/[player]/page.tsx
+++ b/app/player/[player]/page.tsx
@@ -18,6 +18,7 @@ type TPlayerIGN = {
 
 type Props = {
   params: Promise<{ player: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 const NUMBER_REGEX = /^\d+$/;
@@ -45,12 +46,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ player: string }>;
-}) {
-  const currentSeason = await getSeasonCached();
+export default async function Page({ params, searchParams }: Props) {
+  const [{ player }, sp, currentSeason, leagueState] = await Promise.all([
+    params,
+    searchParams,
+    getSeasonCached(),
+    ControlPanel.getLeagueState(),
+  ]);
+
+  if (NUMBER_REGEX.test(player)) return await handleDiscordIDSearch(player);
+
+  const playerIGN: TPlayerIGN = { encoded: "", decoded: "" };
+  if (player.includes(ENCODED_DIVIDER)) playerIGN.encoded = player;
+  else if (player.includes("-")) {
+    const playerSplit = player.split("-");
+    playerIGN.encoded = `${playerSplit[0]}${ENCODED_DIVIDER}${playerSplit[1]}`;
+  } else {
+    return <PlayerNotFound player={decodeURIComponent(player)} />;
+  }
+  playerIGN.decoded = decodeURIComponent(playerIGN.encoded);
+
   const listOfAllSeasons = listAllSeasons(currentSeason);
   const seasonsMenu = listOfAllSeasons.map((season) => ({
     query: season,
@@ -61,23 +76,26 @@ export default async function Page({
     { query: "season", name: "SEASON" },
     { query: "combine", name: "COMBINE" },
   ];
-
-  const leagueState = await ControlPanel.getLeagueState();
   if (leagueState === "COMBINES") {
     gameTypeMenu.reverse();
   }
 
-  const { player } = await params;
-  const playerIGN: TPlayerIGN = { encoded: "", decoded: "" };
-  if (NUMBER_REGEX.test(player)) return await handleDiscordIDSearch(player);
-  else if (player.includes(ENCODED_DIVIDER)) playerIGN.encoded = player;
-  else if (player.includes("-")) {
-    const playerSplit = player.split("-");
-    playerIGN.encoded = `${playerSplit[0]}${ENCODED_DIVIDER}${playerSplit[1]}`;
-  } else {
-    return <PlayerNotFound player={decodeURIComponent(player)} />;
+  const defaultType = leagueState === "COMBINES" ? "combine" : "season";
+  const validTypes = new Set(["season", "combine"]);
+  const validBy = new Set(["summary", "agents", "maps"]);
+  const validSeasons = new Set(listOfAllSeasons);
+
+  const seasonOk = typeof sp.season === "string" && validSeasons.has(sp.season);
+  const typeOk = typeof sp.type === "string" && validTypes.has(sp.type);
+  const byOk = typeof sp.by === "string" && validBy.has(sp.by);
+
+  if (!seasonOk || !typeOk || !byOk) {
+    const next = new URLSearchParams();
+    next.set("season", seasonOk ? (sp.season as string) : currentSeason.toString());
+    next.set("type", typeOk ? (sp.type as string) : defaultType);
+    next.set("by", byOk ? (sp.by as string) : "summary");
+    redirect(`/player/${player}?${next.toString()}`);
   }
-  playerIGN.decoded = decodeURIComponent(playerIGN.encoded);
 
   const tabElements: TTabElements[] = [
     {
@@ -109,7 +127,7 @@ export default async function Page({
           <div className="px-10 xl:px-0 m-auto flex flex-row gap-1 xl:gap-5 w-full">
             <div className="w-full">
               <ListBox
-                params={"Season"}
+                params={"season"}
                 menuElements={seasonsMenu}
                 defaultDropDownQuery={currentSeason.toString()}
               />
@@ -118,7 +136,7 @@ export default async function Page({
               <ListBox
                 params={"type"}
                 menuElements={gameTypeMenu}
-                defaultDropDownQuery={gameTypeMenu.toString()}
+                defaultDropDownQuery={defaultType}
               />
             </div>
           </div>

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -5,6 +5,7 @@ import { getSeasonCached } from "@/lib/common/cache";
 import { TIER_COLOR_MAP, TIERS_LIST } from "@/lib/common/constants";
 import { getUserTier } from "@/lib/queries/user/user";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -15,9 +16,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
-  const CURRENT_SEASON = await getSeasonCached();
-  const userTier = await getUserTier();
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function Page({ searchParams }: Props) {
+  const [sp, CURRENT_SEASON, userTier] = await Promise.all([
+    searchParams,
+    getSeasonCached(),
+    getUserTier(),
+  ]);
+
+  const validTiers = new Set(TIERS_LIST.map((t) => t.toLowerCase()));
+  if (typeof sp.tier !== "string" || !validTiers.has(sp.tier)) {
+    const defaultTier = (userTier || TIERS_LIST[0]).toLowerCase();
+    redirect(`/schedule?tier=${defaultTier}`);
+  }
 
   const tabs: TTabElements[] = TIERS_LIST.map((tier) => ({
     name: tier,

--- a/app/schedule/season/[season]/page.tsx
+++ b/app/schedule/season/[season]/page.tsx
@@ -10,6 +10,7 @@ import { Suspense } from "react";
 
 type Props = {
   params: Promise<{ season: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -20,13 +21,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ season: number }>;
-}) {
-  const currentSeason = await getSeasonCached();
-  const { season } = await params;
+export default async function Page({ params, searchParams }: Props) {
+  const [{ season }, sp, currentSeason] = await Promise.all([
+    params,
+    searchParams,
+    getSeasonCached(),
+  ]);
   const seasonNumber = Number(season);
   const tabs: TTabElements[] = TIERS_LIST.map((tier) => ({
     query: tier,
@@ -37,7 +37,7 @@ export default async function Page({
 
   if (seasonNumber === currentSeason) {
     redirect(`/schedule`);
-  } else if (season > currentSeason) {
+  } else if (seasonNumber > currentSeason) {
     return (
       <div className="flex min-h-screen justify-center items-center">
         <div className="py-10 max-w-7xl xl:py-12 flex flex-col gap-10 text-center">
@@ -52,6 +52,12 @@ export default async function Page({
         </div>
       </div>
     );
+  }
+
+  const validBy = new Set(TIERS_LIST.map((t) => t.toLowerCase()));
+  if (typeof sp.by !== "string" || !validBy.has(sp.by)) {
+    const defaultBy = TIERS_LIST[0].toLowerCase();
+    redirect(`/schedule/season/${season}?by=${defaultBy}`);
   }
 
   return (

--- a/app/standings/page.tsx
+++ b/app/standings/page.tsx
@@ -5,6 +5,7 @@ import { getSeasonCached } from "@/lib/common/cache";
 import { TIER_COLOR_MAP, TIERS_LIST } from "@/lib/common/constants";
 import StandingsPanelSkeleton from "@/components/standings/StandingsPanelSkeleton";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getUserTier } from "@/lib/queries/user/user";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -15,9 +16,25 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Standings() {
-  const CURRENT_SEASON = await getSeasonCached();
-  const userTier = await getUserTier();
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function Standings({ searchParams }: Props) {
+  const [sp, CURRENT_SEASON, userTier] = await Promise.all([
+    searchParams,
+    getSeasonCached(),
+    getUserTier(),
+  ]);
+
+  const validBy = new Set([
+    "franchises",
+    ...TIERS_LIST.map((t) => t.toLowerCase()),
+  ]);
+  if (typeof sp.by !== "string" || !validBy.has(sp.by)) {
+    const defaultBy = (userTier || "franchises").toLowerCase();
+    redirect(`/standings?by=${defaultBy}`);
+  }
 
   const tabs: TTabElements[] = TIERS_LIST.map((tier) => ({
     query: tier,

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -9,6 +9,7 @@ import { getUserTier } from "@/lib/queries/user/user";
 import { ControlPanel } from "@/prisma";
 import { GameType, Tier } from "@prisma/client";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 export const metadata: Metadata = {
@@ -16,15 +17,43 @@ export const metadata: Metadata = {
   description: `Valorant Draft Circuit player stats page.`,
 };
 
-export default async function Page() {
-  const seasonState = await ControlPanel.getLeagueState();
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function Page({ searchParams }: Props) {
+  const [sp, seasonState, currentSeason, userTier] = await Promise.all([
+    searchParams,
+    ControlPanel.getLeagueState(),
+    getSeasonCached(),
+    getUserTier({ isStats: true }),
+  ]);
+
   const gameTypes: GameType[] = [GameType.SEASON, GameType.COMBINE];
   if (seasonState === "COMBINES") {
     gameTypes.reverse();
   }
 
-  const currentSeason = await getSeasonCached();
   const listOfAllSeasons = listAllSeasons(currentSeason);
+
+  const defaultType = gameTypes[0].toLowerCase();
+  const defaultTier = (userTier || Tier.MYTHIC).toLowerCase();
+  const validTypes = new Set(gameTypes.map((g) => g.toLowerCase()));
+  const validTiers = new Set(TIERS_LIST.map((t) => t.toLowerCase()));
+  const validSeasons = new Set(listOfAllSeasons);
+
+  const seasonOk = typeof sp.season === "string" && validSeasons.has(sp.season);
+  const typeOk = typeof sp.type === "string" && validTypes.has(sp.type);
+  const tierOk = typeof sp.tier === "string" && validTiers.has(sp.tier);
+
+  if (!seasonOk || !typeOk || !tierOk) {
+    const next = new URLSearchParams();
+    next.set("season", seasonOk ? (sp.season as string) : currentSeason.toString());
+    next.set("type", typeOk ? (sp.type as string) : defaultType);
+    next.set("tier", tierOk ? (sp.tier as string) : defaultTier);
+    redirect(`/stats?${next.toString()}`);
+  }
+
   const seasonList = listOfAllSeasons.map((season) => ({
     query: season,
     name: `SEASON ${season}`,
@@ -34,8 +63,6 @@ export default async function Page() {
     query: game.toLocaleLowerCase(),
     name: `${game.replace("_", "")}`,
   }));
-
-  const userTier = await getUserTier({ isStats: true });
 
   const defaultQueries = {
     season: currentSeason,

--- a/components/tabs/DropDown.tsx
+++ b/components/tabs/DropDown.tsx
@@ -8,7 +8,6 @@ import {
 } from "@headlessui/react";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
 
 type TMenuElement = { query: string; name: string };
 
@@ -22,45 +21,28 @@ export default function ListBox({
   defaultDropDownQuery: string;
 }) {
   const paramsKey = params.toLowerCase();
-
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const urlParam = searchParams.get(paramsKey) ?? menuElements[0].query;
 
-  const [selected, setSelected] = useState<TMenuElement>(
-    menuElements.find((m) => m.query === urlParam) || menuElements[0],
-  );
+  const queryValue =
+    searchParams.get(paramsKey) ?? defaultDropDownQuery.toLowerCase();
+  const selected =
+    menuElements.find(
+      (m) => m.query.toString().toLowerCase() === queryValue.toLowerCase(),
+    ) ?? menuElements[0];
 
-  useEffect(() => {
-    const params = new URLSearchParams(searchParams);
-    const current = params.get(paramsKey);
-
-    if (!current) {
-      params.set(paramsKey, defaultDropDownQuery.toLowerCase());
-      router.replace(`${pathname}?${params.toString()}`);
-      return;
-    }
-
-    if (current !== selected.query) {
-      params.set(paramsKey, selected.query);
-      router.push(`${pathname}?${params.toString()}`);
-    }
-  }, [selected, searchParams]);
-
-  useEffect(() => {
-    const newParam = searchParams.get(paramsKey) ?? menuElements[0].query;
-    const matched = menuElements.find((m) => m.query === newParam);
-    if (matched && matched.query !== selected.query) {
-      setSelected(matched);
-    }
-  }, [searchParams]);
+  const handleChange = (next: TMenuElement) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(paramsKey, next.query.toString().toLowerCase());
+    router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
+  };
 
   return (
     <div className="xl:px-0 sm:px-12 relative">
-      <Listbox value={selected} onChange={setSelected}>
+      <Listbox value={selected} onChange={handleChange}>
         <ListboxButton
-          className="relative flex flex-row rounded-md py-2 pl-4 pr-8 w-full 
+          className="relative flex flex-row rounded-md py-2 pl-4 pr-8 w-full
           dark:bg-vdcBlack text-sm text-vdcGrey dark:text-vdcWhite outline-1 -outline-offset-1 outline-gray-300 data-hover:cursor-pointer"
         >
           <h2>{selected.name}</h2>

--- a/components/tabs/HorizontalTab.tsx
+++ b/components/tabs/HorizontalTab.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
-import { useEffect, useState } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {
   Listbox,
@@ -28,105 +27,74 @@ export default function HorizontalTab({
   params: string;
   defaultQuery?: string;
 }) {
-  const searchParams = useSearchParams();
-  const queryParam = searchParams.get(params)?.toLowerCase();
-
-  const fallbackQuery =
-    defaultQuery?.toLowerCase() || tabElements[0].query.toLowerCase();
-  const effectiveQuery = queryParam || fallbackQuery;
-
-  useEffect(() => {
-    if (!queryParam) {
-      replaceParam(params, fallbackQuery);
-    }
-  }, [queryParam]);
-
-  const initialIndex = tabElements.findIndex(
-    (t) => t.query.toLowerCase() === effectiveQuery,
-  );
-
-  const [selectedIndex, setSelectedIndex] = useState(
-    initialIndex >= 0 ? initialIndex : 0,
-  );
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  useEffect(() => {
-    if (initialIndex !== selectedIndex && initialIndex >= 0) {
-      setSelectedIndex(initialIndex);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialIndex]);
+  const fallbackQuery =
+    defaultQuery?.toLowerCase() ?? tabElements[0].query.toLowerCase();
+  const activeQuery =
+    searchParams.get(params)?.toLowerCase() ?? fallbackQuery;
 
-  const updateParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set(key, value);
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
+  const derivedIndex = tabElements.findIndex(
+    (t) => t.query.toLowerCase() === activeQuery,
+  );
+  const selectedIndex = derivedIndex >= 0 ? derivedIndex : 0;
 
-  const replaceParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set(key, value);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  const handleChange = (index: number) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(params, tabElements[index].query.toLowerCase());
+    router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
   };
 
   return (
-    <>
-      <TabGroup
-        selectedIndex={selectedIndex}
-        onChange={(index) => {
-          setSelectedIndex(index);
-          const newQuery = tabElements[index].query.toLowerCase();
-          updateParam(params, newQuery);
-        }}
-        className="flex flex-col xl:flex"
-      >
-        <div className="xl:hidden sticky top-0 z-40 bg-vdcWhite dark:bg-vdcBlack mx-auto w-full pt-5 px-10 sm:px-12 ">
-          <MobileTabs
-            setSelected={(idx: number) => {
-              setSelectedIndex(idx);
-              updateParam(params, tabElements[idx].query.toLowerCase());
-            }}
-            selected={selectedIndex}
-            tabElements={tabElements}
-          />
-        </div>
+    <TabGroup
+      selectedIndex={selectedIndex}
+      onChange={handleChange}
+      className="flex flex-col xl:flex"
+    >
+      <div className="xl:hidden sticky top-0 z-40 bg-vdcWhite dark:bg-vdcBlack mx-auto w-full pt-5 px-10 sm:px-12 ">
+        <MobileTabs
+          tabElements={tabElements}
+          selected={selectedIndex}
+          onSelect={handleChange}
+        />
+      </div>
 
-        <div className="hidden xl:block">
-          <div className="flex flex-row gap-2 sticky top-26 self-start">
-            <div className="p-2 drop-shadow-lg bg-gray-100 dark:bg-vdcGrey rounded-md w-full">
-              <TabList className="flex flex-row items-start gap-5 rounded-2xl drop-shadow-2xl">
-                {tabElements.map(({ name, color }) => (
-                  <Tab
-                    key={name}
-                    className={`text-xl border-b-2 text-vdcBlack dark:text-vdcWhite py-1 text-center mx-auto px-5 focus:not-data-focus:outline-none data-hover:text-${color} data-hover:border-${color} data-hover:cursor-pointer data-selected:text-${color}`}
-                  >
-                    <h1 className="italic">{name}</h1>
-                  </Tab>
-                ))}
-              </TabList>
-            </div>
+      <div className="hidden xl:block">
+        <div className="flex flex-row gap-2 sticky top-26 self-start">
+          <div className="p-2 drop-shadow-lg bg-gray-100 dark:bg-vdcGrey rounded-md w-full">
+            <TabList className="flex flex-row items-start gap-5 rounded-2xl drop-shadow-2xl">
+              {tabElements.map(({ name, color }) => (
+                <Tab
+                  key={name}
+                  className={`text-xl border-b-2 text-vdcBlack dark:text-vdcWhite py-1 text-center mx-auto px-5 focus:not-data-focus:outline-none data-hover:text-${color} data-hover:border-${color} data-hover:cursor-pointer data-selected:text-${color}`}
+                >
+                  <h1 className="italic">{name}</h1>
+                </Tab>
+              ))}
+            </TabList>
           </div>
         </div>
+      </div>
 
-        <TabPanels className="flex flex-col gap-2 p-3 xl:px-0 ">
-          {tabElements.map(({ content, query: query }) => (
-            <TabPanel key={query}>{content}</TabPanel>
-          ))}
-        </TabPanels>
-      </TabGroup>
-    </>
+      <TabPanels className="flex flex-col gap-2 p-3 xl:px-0 ">
+        {tabElements.map(({ content, query }) => (
+          <TabPanel key={query}>{content}</TabPanel>
+        ))}
+      </TabPanels>
+    </TabGroup>
   );
 }
 
-export function MobileTabs({
+function MobileTabs({
   tabElements,
-  setSelected,
   selected,
+  onSelect,
 }: {
-  tabElements;
-  setSelected;
-  selected;
+  tabElements: TTabElements[];
+  selected: number;
+  onSelect: (index: number) => void;
 }) {
   const selectedTab = tabElements[selected];
 
@@ -136,7 +104,7 @@ export function MobileTabs({
         value={selectedTab}
         onChange={(tab) => {
           const idx = tabElements.findIndex((t) => t.query === tab.query);
-          if (idx >= 0) setSelected(idx);
+          if (idx >= 0) onSelect(idx);
         }}
       >
         <div className="relative col-start-1 row-start-1">

--- a/components/tabs/VerticalTab.tsx
+++ b/components/tabs/VerticalTab.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
-import { useEffect, useState } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {
   Listbox,
@@ -28,105 +27,75 @@ export default function VerticalTab({
   params: string;
   defaultQuery?: string;
 }) {
-  const searchParams = useSearchParams();
-  const queryParam = searchParams.get(params)?.toLowerCase();
-
-  useEffect(() => {
-    if (!queryParam) {
-      const fallback =
-        defaultQuery?.toLowerCase() || tabElements[0].query.toLowerCase();
-      replaceParam(params, fallback);
-    }
-  }, [queryParam]);
-
-  const initialQuery = queryParam || defaultQuery || tabElements[0].query;
-  const initialIndex = tabElements.findIndex(
-    (t) => t.query.toLowerCase() === initialQuery.toLowerCase(),
-  );
-
-  const [selectedIndex, setSelectedIndex] = useState(
-    initialIndex >= 0 ? initialIndex : 0,
-  );
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  useEffect(() => {
-    if (initialIndex !== selectedIndex && initialIndex >= 0) {
-      setSelectedIndex(initialIndex);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialIndex]);
+  const fallbackQuery =
+    defaultQuery?.toLowerCase() ?? tabElements[0].query.toLowerCase();
+  const activeQuery =
+    searchParams.get(params)?.toLowerCase() ?? fallbackQuery;
 
-  const updateParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set(key, value);
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
+  const derivedIndex = tabElements.findIndex(
+    (t) => t.query.toLowerCase() === activeQuery,
+  );
+  const selectedIndex = derivedIndex >= 0 ? derivedIndex : 0;
 
-  const replaceParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set(key, value);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  const handleChange = (index: number) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(params, tabElements[index].query.toLowerCase());
+    router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
   };
 
   return (
-    <>
-      <TabGroup
-        selectedIndex={selectedIndex}
-        onChange={(index) => {
-          setSelectedIndex(index);
-          const newQuery = tabElements[index].query.toLowerCase();
-          updateParam(params, newQuery);
-        }}
-        vertical
-        className="flex flex-col xl:flex-row"
-      >
-        <div className="xl:hidden sticky top-0 z-40 bg-vdcWhite dark:bg-vdcBlack mx-auto w-screen pt-5 px-5 sm:px-12 ">
-          <MobileTabs
-            setSelected={(idx: number) => {
-              setSelectedIndex(idx);
-              updateParam(params, tabElements[idx].query.toLowerCase());
-            }}
-            selected={selectedIndex}
-            tabElements={tabElements}
-          />
-        </div>
+    <TabGroup
+      selectedIndex={selectedIndex}
+      onChange={handleChange}
+      vertical
+      className="flex flex-col xl:flex-row"
+    >
+      <div className="xl:hidden sticky top-0 z-40 bg-vdcWhite dark:bg-vdcBlack mx-auto w-screen pt-5 px-5 sm:px-12 ">
+        <MobileTabs
+          tabElements={tabElements}
+          selected={selectedIndex}
+          onSelect={handleChange}
+        />
+      </div>
 
-        <div className="hidden xl:block">
-          <div className="flex flex-row gap-2 sticky top-26 self-start">
-            <div className="p-4 drop-shadow-lg bg-gray-100 dark:bg-vdcGrey rounded-2xl">
-              <TabList className="flex flex-col items-start gap-1 rounded-2xl drop-shadow-2xl">
-                {tabElements.map(({ name, color }) => (
-                  <Tab
-                    key={name}
-                    className={`rounded-lg text-xl text-vdcBlack dark:text-vdcWhite py-1 text-start w-42 px-2 data-hover:bg-gray-300 dark:data-hover:bg-vdcBlack focus:not-data-focus:outline-none data-hover:text-${color} data-hover:cursor-pointer data-selected:bg-gray-300 dark:data-selected:bg-vdcBlack data-selected:text-${color}`}
-                  >
-                    <h1 className="italic">{name}</h1>
-                  </Tab>
-                ))}
-              </TabList>
-            </div>
+      <div className="hidden xl:block">
+        <div className="flex flex-row gap-2 sticky top-26 self-start">
+          <div className="p-4 drop-shadow-lg bg-gray-100 dark:bg-vdcGrey rounded-2xl">
+            <TabList className="flex flex-col items-start gap-1 rounded-2xl drop-shadow-2xl">
+              {tabElements.map(({ name, color }) => (
+                <Tab
+                  key={name}
+                  className={`rounded-lg text-xl text-vdcBlack dark:text-vdcWhite py-1 text-start w-42 px-2 data-hover:bg-gray-300 dark:data-hover:bg-vdcBlack focus:not-data-focus:outline-none data-hover:text-${color} data-hover:cursor-pointer data-selected:bg-gray-300 dark:data-selected:bg-vdcBlack data-selected:text-${color}`}
+                >
+                  <h1 className="italic">{name}</h1>
+                </Tab>
+              ))}
+            </TabList>
           </div>
         </div>
+      </div>
 
-        <TabPanels className="w-auto sm:w-xl md:w-2xl xl:w-4xl flex flex-col gap-2 m-auto p-3 rounded-2xl">
-          {tabElements.map(({ content, query: query }) => (
-            <TabPanel key={query}>{content}</TabPanel>
-          ))}
-        </TabPanels>
-      </TabGroup>
-    </>
+      <TabPanels className="w-auto sm:w-xl md:w-2xl xl:w-4xl flex flex-col gap-2 m-auto p-3 rounded-2xl">
+        {tabElements.map(({ content, query }) => (
+          <TabPanel key={query}>{content}</TabPanel>
+        ))}
+      </TabPanels>
+    </TabGroup>
   );
 }
 
 function MobileTabs({
   tabElements,
-  setSelected,
   selected,
+  onSelect,
 }: {
   tabElements: TTabElements[];
-  setSelected;
-  selected;
+  selected: number;
+  onSelect: (index: number) => void;
 }) {
   const selectedTab: TTabElements = tabElements[selected];
 
@@ -136,7 +105,7 @@ function MobileTabs({
         value={selectedTab}
         onChange={(tab) => {
           const idx = tabElements.findIndex((t) => t.query === tab.query);
-          if (idx >= 0) setSelected(idx);
+          if (idx >= 0) onSelect(idx);
         }}
       >
         <div className="relative col-start-1 row-start-1">


### PR DESCRIPTION
## Test plan

- [x] `/player/<player>` fresh visit → canonical URL, stats populate on first paint
- [x] `/player/<player>` → click dropdowns/tabs → press Back repeatedly → no oscillation
- [x] `/player/<player>?type=banana` → corrected to a valid `type`
- [x] `/stats` fresh visit → canonical URL, table populates
- [x] `/franchises/<valid-slug>` fresh visit → canonical URL, tab renders
- [ ] `/franchises/<invalid-slug>` → 404 instead of crash
- [x] `/standings`, `/schedule`, `/schedule/season/<old-season>` fresh visit → each canonical, tabs render
- [x] `/player/<player>` → pick a non-current season → dropdown label matches URL