### PR TITLE
Dla/player agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ pnpm-workspace.yaml
 
 # local design notes
 /docs
+/.superpowers
+
+# agents
+AGENTS.md
+.mcp.json

--- a/app/player/[player]/page.tsx
+++ b/app/player/[player]/page.tsx
@@ -19,6 +19,9 @@ import {
   getRiotIGNByDiscordId,
 } from "@/lib/queries/user/user";
 import { getPlayerStatsBy } from "@/lib/queries/stats/stats";
+import { getAgentCatalog } from "@/lib/queries/agents/getAgentCatalog";
+import { getPlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import { agentToUrlSlug } from "@/lib/common/agents";
 
 type PlayerIGN = {
   encoded: string;
@@ -33,8 +36,16 @@ type Props = {
 const NUMBER_REGEX = /^\d+$/;
 const ENCODED_DIVIDER = encodeURIComponent("#");
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { player } = await params;
+export async function generateMetadata({
+  params,
+  searchParams,
+}: Props): Promise<Metadata> {
+  const [{ player }, sp, currentSeason] = await Promise.all([
+    params,
+    searchParams,
+    getSeasonCached(),
+  ]);
+
   let playerIGN: string;
   if (NUMBER_REGEX.test(player)) {
     const riotIGN = await getRiotIGNByDiscordId(player);
@@ -42,10 +53,66 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   } else {
     playerIGN = decodeURIComponent(player);
   }
-  return {
-    title: `VDC | ${playerIGN}'s Player Page`,
-    description: `${playerIGN} information`,
+
+  const baseTitle = `VDC | ${playerIGN}'s Player Page`;
+  const baseDescription = `${playerIGN} information`;
+  const fallback: Metadata = {
+    title: baseTitle,
+    description: baseDescription,
   };
+
+  if (sp.by !== "agents" || typeof sp.agent !== "string") {
+    return fallback;
+  }
+
+  try {
+    const season =
+      typeof sp.season === "string" ? parseInt(sp.season) : currentSeason;
+    const gameType: GameType =
+      sp.type === "combine" ? GameType.COMBINE : GameType.SEASON;
+    const catalog = await getAgentCatalog();
+    const breakdown = await getPlayerAgentBreakdown({
+      riotIgn: playerIGN,
+      season,
+      gameType,
+      catalog,
+    });
+
+    const selected = breakdown.find(
+      (e) => agentToUrlSlug(e.catalog?.displayName ?? e.agent) === sp.agent,
+    );
+    if (!selected || !selected.catalog) return fallback;
+
+    const rating =
+      (selected.averages.ratingAttack + selected.averages.ratingDefense) / 2;
+    const winPct =
+      selected.gamesPlayed === 0
+        ? 0
+        : (selected.wins / selected.gamesPlayed) * 100;
+    const agentName = selected.catalog.displayName;
+    const ogTitle = `${agentName} on ${playerIGN} | VDC`;
+    const ogDescription = `${rating.toFixed(2)} rating · ${selected.gamesPlayed} games · ${winPct.toFixed(0)}% WR as ${agentName}`;
+    const ogImage = selected.catalog.fullPortraitUrl;
+
+    return {
+      title: ogTitle,
+      description: ogDescription,
+      openGraph: {
+        title: ogTitle,
+        description: ogDescription,
+        type: "profile",
+        images: ogImage ? [{ url: ogImage }] : undefined,
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: ogTitle,
+        description: ogDescription,
+        images: ogImage ? [ogImage] : undefined,
+      },
+    };
+  } catch {
+    return fallback;
+  }
 }
 
 export default async function Page({ params, searchParams }: Props) {
@@ -122,7 +189,15 @@ export default async function Page({ params, searchParams }: Props) {
       query: "Agents",
       color: "vdcRed",
       name: "Agents",
-      content: <PlayerAgents />,
+      content: (
+        <PlayerAgents
+          riotIGN={playerIGN.decoded}
+          season={season}
+          gameType={gameTypeParam}
+          basePath={`/player/${player}`}
+          searchParams={sp}
+        />
+      ),
     },
     {
       query: "Maps",

--- a/components/player/CombineDisclaimer.tsx
+++ b/components/player/CombineDisclaimer.tsx
@@ -1,0 +1,22 @@
+import { InformationCircleIcon } from "@heroicons/react/16/solid";
+
+export default function CombineDisclaimer() {
+  return (
+    <div className="rounded-md bg-vdcRed/30 dark:bg-vdcRed/10 p-4 mx-2 xl:mx-0 outline outline-vdcRed/20">
+      <div className="flex">
+        <div className="shrink-0">
+          <InformationCircleIcon
+            aria-hidden="true"
+            className="size-5 text-vdcRed"
+          />
+        </div>
+        <div className="ml-3 flex-1 md:flex md:justify-between">
+          <p className="text-sm text-vdcBlack dark:text-vdcWhite font-roboto italic">
+            Combine stats are stored differently than regular season stats. Some
+            data might be different or missing entirely.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/player/PlayerAgents.tsx
+++ b/components/player/PlayerAgents.tsx
@@ -1,8 +1,32 @@
-import Soon from "../theme/Soon";
+import { Suspense } from "react";
+import { GameType } from "@prisma/client";
+import PlayerAgentsLoader from "@/components/player/agents/PlayerAgentsLoader";
+import PlayerAgentsSkeleton from "@/components/player/agents/PlayerAgentsSkeleton";
 
-export default function PlayerAgents() {
-  const wip = true;
-  if (wip) {
-    return <Soon />;
-  }
+type Props = {
+  riotIGN: string;
+  season: number;
+  gameType: GameType;
+  basePath: string;
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+export default function PlayerAgents({
+  riotIGN,
+  season,
+  gameType,
+  basePath,
+  searchParams,
+}: Props) {
+  return (
+    <Suspense fallback={<PlayerAgentsSkeleton />}>
+      <PlayerAgentsLoader
+        riotIGN={riotIGN}
+        season={season}
+        gameType={gameType}
+        basePath={basePath}
+        searchParams={searchParams}
+      />
+    </Suspense>
+  );
 }

--- a/components/player/agents/AgentTable.tsx
+++ b/components/player/agents/AgentTable.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/16/solid";
+import { agentToUrlSlug } from "@/lib/common/agents";
+import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+
+type SortCol =
+  | "agent"
+  | "gp"
+  | "winrate"
+  | "rating"
+  | "acs"
+  | "kd"
+  | "adr"
+  | "kast"
+  | "hs";
+type SortDir = "asc" | "desc";
+
+type Props = {
+  rows: PlayerAgentBreakdown[];
+  selectedSlug: string;
+  basePath: string;
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+const COLUMNS: Array<{ key: SortCol; label: string; defaultDir: SortDir }> = [
+  { key: "agent", label: "Agent", defaultDir: "asc" },
+  { key: "gp", label: "Games", defaultDir: "desc" },
+  { key: "winrate", label: "WR", defaultDir: "desc" },
+  { key: "rating", label: "Rating", defaultDir: "desc" },
+  { key: "acs", label: "ACS", defaultDir: "desc" },
+  { key: "kd", label: "KD", defaultDir: "desc" },
+  { key: "adr", label: "ADR", defaultDir: "desc" },
+  { key: "kast", label: "KAST", defaultDir: "desc" },
+  { key: "hs", label: "HS%", defaultDir: "desc" },
+];
+
+function rowValue(row: PlayerAgentBreakdown, col: SortCol): number | string {
+  switch (col) {
+    case "agent":
+      return row.catalog?.displayName ?? row.agent;
+    case "gp":
+      return row.gamesPlayed;
+    case "winrate":
+      return row.gamesPlayed === 0 ? 0 : row.wins / row.gamesPlayed;
+    case "rating":
+      return (row.averages.ratingAttack + row.averages.ratingDefense) / 2;
+    case "acs":
+      return row.averages.acs;
+    case "kd":
+      return row.totals.deaths === 0
+        ? row.totals.kills
+        : row.totals.kills / row.totals.deaths;
+    case "adr":
+      return row.rounds === 0 ? 0 : row.totals.damage / row.rounds;
+    case "kast":
+      return row.averages.kast;
+    case "hs":
+      return row.averages.hsPercent;
+  }
+}
+
+function buildAgentHref(
+  basePath: string,
+  searchParams: Record<string, string | string[] | undefined>,
+  slug: string,
+): string {
+  const next = new URLSearchParams();
+  for (const [k, v] of Object.entries(searchParams)) {
+    if (typeof v === "string") next.set(k, v);
+  }
+  next.set("agent", slug);
+  return `${basePath}?${next.toString()}`;
+}
+
+export default function AgentTable({
+  rows,
+  selectedSlug,
+  basePath,
+  searchParams,
+}: Props) {
+  const [sort, setSort] = useState<{ col: SortCol; dir: SortDir }>({
+    col: "gp",
+    dir: "desc",
+  });
+
+  const sortedRows = useMemo(() => {
+    const copy = [...rows];
+    copy.sort((a, b) => {
+      const av = rowValue(a, sort.col);
+      const bv = rowValue(b, sort.col);
+      const cmp =
+        typeof av === "string" && typeof bv === "string"
+          ? av.localeCompare(bv)
+          : (av as number) - (bv as number);
+      return sort.dir === "asc" ? cmp : -cmp;
+    });
+    return copy;
+  }, [rows, sort]);
+
+  function onHeaderClick(col: SortCol, defaultDir: SortDir) {
+    setSort((s) =>
+      s.col === col
+        ? { col, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { col, dir: defaultDir },
+    );
+  }
+
+  return (
+    <div className="overflow-auto rounded-2xl border border-gray-200 dark:border-gray-600 mx-2 xl:mx-0">
+      <table className="mx-auto w-full">
+        <thead>
+          <tr>
+            {COLUMNS.map((c) => {
+              const active = sort.col === c.key;
+              const isFirst = c.key === "agent";
+              return (
+                <th
+                  key={c.key}
+                  className={`sticky top-0 border-b italic border-gray-300 bg-gray-100 dark:bg-vdcBlack dark:text-vdcWhite p-4 text-xs xl:text-sm backdrop-blur-sm z-10 ${
+                    isFirst ? "left-0 z-30 bg-white dark:bg-vdcBlack" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onHeaderClick(c.key, c.defaultDir)}
+                    className={`flex flex-row items-center cursor-pointer select-none hover:text-vdcRed ${
+                      active ? "text-vdcRed" : ""
+                    }`}
+                  >
+                    <h1>{c.label}</h1>
+                    {active &&
+                      (sort.dir === "asc" ? (
+                        <ChevronUpIcon className="size-5" />
+                      ) : (
+                        <ChevronDownIcon className="size-5" />
+                      ))}
+                  </button>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedRows.map((row, idx) => {
+            const slug = agentToUrlSlug(row.catalog?.displayName ?? row.agent);
+            const winPct =
+              row.gamesPlayed === 0 ? 0 : (row.wins / row.gamesPlayed) * 100;
+            const rating =
+              (row.averages.ratingAttack + row.averages.ratingDefense) / 2;
+            const kd =
+              row.totals.deaths === 0
+                ? row.totals.kills
+                : row.totals.kills / row.totals.deaths;
+            const adr = row.rounds === 0 ? 0 : row.totals.damage / row.rounds;
+            const role = row.catalog?.role;
+            const isSelected = slug === selectedSlug;
+
+            const rowBg = isSelected ? "bg-vdcRed/15" : "";
+            const firstCellBg = "bg-vdcWhite dark:bg-vdcBlack";
+            const rowHover = isSelected
+              ? "hover:bg-vdcRed/25"
+              : "hover:bg-gray-300 dark:hover:bg-vdcGrey/40";
+            const stickyHover = "group-hover:bg-gray-200 dark:group-hover:bg-vdcGrey";
+
+            return (
+              <tr
+                key={row.agent}
+                className={`group ${rowBg} ${rowHover} transition-colors`}
+              >
+                <td
+                  className={`relative border-b border-r border-gray-200 dark:border-gray-600 whitespace-nowrap px-3 py-2 text-xs xl:text-sm dark:text-white sticky left-0 z-10 transition-colors ${firstCellBg} ${stickyHover}`}
+                >
+                  {isSelected && (
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute left-0 top-0 bottom-0 w-1 bg-vdcRed"
+                    />
+                  )}
+                  <Link
+                    href={buildAgentHref(basePath, searchParams, slug)}
+                    scroll={false}
+                    className="flex items-center gap-2"
+                  >
+                    {row.catalog?.displayIconUrl ? (
+                      <Image
+                        src={row.catalog.displayIconUrl}
+                        alt={row.catalog.displayName}
+                        width={40}
+                        height={40}
+                        className="rounded w-10 h-10"
+                      />
+                    ) : (
+                      <span className="w-10 h-10 rounded bg-vdcBlack/30" />
+                    )}
+                    <h2 className="truncate">
+                      {row.catalog?.displayName ?? row.agent}
+                    </h2>
+                    {role && (
+                      <Image
+                        src={role.iconUrl}
+                        alt={role.name}
+                        width={16}
+                        height={16}
+                        className="w-4 h-4 invert dark:invert-0"
+                      />
+                    )}
+                  </Link>
+                </td>
+                <Cell value={row.gamesPlayed} />
+                <Cell value={`${winPct.toFixed(0)}%`} />
+                <Cell value={rating.toFixed(2)} />
+                <Cell value={row.averages.acs.toFixed(0)} />
+                <Cell value={kd.toFixed(2)} />
+                <Cell value={adr.toFixed(0)} />
+                <Cell value={`${row.averages.kast.toFixed(0)}%`} />
+                <Cell value={`${row.averages.hsPercent.toFixed(0)}%`} />
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Cell({ value }: { value: string | number }) {
+  return (
+    <td className="border-b border-r border-gray-200 dark:border-gray-600 whitespace-nowrap px-3 py-2 text-xs xl:text-sm dark:text-white">
+      <h2>{value}</h2>
+    </td>
+  );
+}

--- a/components/player/agents/AgentTable.tsx
+++ b/components/player/agents/AgentTable.tsx
@@ -166,6 +166,17 @@ export default function AgentTable({
               : "hover:bg-gray-300 dark:hover:bg-vdcGrey/40";
             const stickyHover = "group-hover:bg-gray-200 dark:group-hover:bg-vdcGrey";
 
+            const dataCells: Array<[SortCol, string | number]> = [
+              ["gp", row.gamesPlayed],
+              ["winrate", `${winPct.toFixed(0)}%`],
+              ["rating", rating.toFixed(2)],
+              ["acs", row.averages.acs.toFixed(0)],
+              ["kd", kd.toFixed(2)],
+              ["adr", adr.toFixed(0)],
+              ["kast", `${row.averages.kast.toFixed(0)}%`],
+              ["hs", `${row.averages.hsPercent.toFixed(0)}%`],
+            ];
+
             return (
               <tr
                 key={row.agent}
@@ -210,14 +221,9 @@ export default function AgentTable({
                     )}
                   </Link>
                 </td>
-                <Cell value={row.gamesPlayed} />
-                <Cell value={`${winPct.toFixed(0)}%`} />
-                <Cell value={rating.toFixed(2)} />
-                <Cell value={row.averages.acs.toFixed(0)} />
-                <Cell value={kd.toFixed(2)} />
-                <Cell value={adr.toFixed(0)} />
-                <Cell value={`${row.averages.kast.toFixed(0)}%`} />
-                <Cell value={`${row.averages.hsPercent.toFixed(0)}%`} />
+                {dataCells.map(([key, value]) => (
+                  <Cell key={key} value={value} />
+                ))}
               </tr>
             );
           })}

--- a/components/player/agents/AgentTable.tsx
+++ b/components/player/agents/AgentTable.tsx
@@ -145,7 +145,7 @@ export default function AgentTable({
           </tr>
         </thead>
         <tbody>
-          {sortedRows.map((row, idx) => {
+          {sortedRows.map((row) => {
             const slug = agentToUrlSlug(row.catalog?.displayName ?? row.agent);
             const winPct =
               row.gamesPlayed === 0 ? 0 : (row.wins / row.gamesPlayed) * 100;

--- a/components/player/agents/BestGameCard.tsx
+++ b/components/player/agents/BestGameCard.tsx
@@ -1,0 +1,128 @@
+import Image from "next/image";
+import Link from "next/link";
+import { MAPS, MAP_LIST_URL, TEAM_LOGOS_URL } from "@/lib/common/constants";
+import type { BestGameRef } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import type { TeamLogoInfo, TeamLogoMap } from "@/lib/queries/teams/teams";
+
+type Props = {
+  ref_: BestGameRef;
+  teamMap: TeamLogoMap;
+  variant?: "hero" | "standalone";
+  label?: string;
+};
+
+function teamSide(ref_: BestGameRef): "home" | "away" | null {
+  if (ref_.playerTeamId === null) return null;
+  if (ref_.playerTeamId === ref_.home) return "home";
+  if (ref_.playerTeamId === ref_.away) return "away";
+  return null;
+}
+
+function playerWon(ref_: BestGameRef): boolean | null {
+  const side = teamSide(ref_);
+  if (side === "home") return ref_.homeRoundsWon > ref_.awayRoundsWon;
+  if (side === "away") return ref_.awayRoundsWon > ref_.homeRoundsWon;
+  return null;
+}
+
+export default function BestGameCard({
+  ref_,
+  teamMap,
+  variant = "hero",
+  label = "Best game",
+}: Props) {
+  const mapKey = (ref_.map ?? "").toUpperCase();
+  const mapUuid = (MAPS as Record<string, string>)[mapKey];
+  const mapImageUrl = mapUuid ? MAP_LIST_URL(mapUuid) : null;
+  const home = ref_.home !== null ? teamMap[ref_.home] : undefined;
+  const away = ref_.away !== null ? teamMap[ref_.away] : undefined;
+  const wonGame = playerWon(ref_);
+  const side = teamSide(ref_);
+
+  const containerClasses =
+    variant === "hero"
+      ? "block rounded-md bg-slate-100/40 dark:bg-vdcBlack/40 backdrop-blur-sm border border-black/5 dark:border-white/5 p-3 hover:brightness-110"
+      : "block rounded-md bg-slate-100 dark:bg-vdcGrey p-4 hover:brightness-110";
+
+  return (
+    <Link
+      href={`/match/${ref_.matchID}?game=${ref_.gameID}`}
+      className={containerClasses}
+    >
+      <h1 className="text-xs uppercase tracking-wider text-vdcBlack dark:text-gray-400 mb-3">
+        {label}
+      </h1>
+      <div className="grid grid-cols-[88px_1fr] gap-4 items-center">
+        {mapImageUrl ? (
+          <Image
+            src={mapImageUrl}
+            alt={ref_.map ?? "Map"}
+            width={200}
+            height={200}
+            className="rounded object-cover h-[88px] w-[88px]"
+          />
+        ) : (
+          <div className="rounded bg-vdcBlack/30 h-[88px] w-[88px]" />
+        )}
+        <div className="flex flex-col">
+          <h1 className="text-3xl font-bold leading-none text-vdcBlack dark:text-vdcWhite">
+            {ref_.acs} <span className="text-gray-500 text-lg">ACS</span>
+          </h1>
+          <h1 className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1">
+            {ref_.map ?? "Unknown map"}
+          </h1>
+          <h1 className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+            <strong className="text-vdcBlack dark:text-vdcWhite">
+              {ref_.kills}
+            </strong>{" "}
+            kills
+          </h1>
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-3 mt-4">
+        <TeamPill
+          info={home}
+          highlight={side === "home" ? (wonGame ? "win" : "lose") : "neutral"}
+        />
+        <h2 className="text-xl font-bold text-vdcBlack dark:text-vdcWhite tabular-nums">
+          {ref_.homeRoundsWon} - {ref_.awayRoundsWon}
+        </h2>
+        <TeamPill
+          info={away}
+          highlight={side === "away" ? (wonGame ? "win" : "lose") : "neutral"}
+        />
+      </div>
+    </Link>
+  );
+}
+
+function TeamPill({
+  info,
+  highlight,
+}: {
+  info: TeamLogoInfo | undefined;
+  highlight: "win" | "lose" | "neutral";
+}) {
+  const colorClass =
+    highlight === "win"
+      ? "text-vdcGreen"
+      : highlight === "lose"
+        ? "text-red-500"
+        : "text-vdcBlack dark:text-vdcWhite";
+  return (
+    <span className={`flex items-center gap-2 font-semibold ${colorClass}`}>
+      {info?.logoPath ? (
+        <Image
+          src={`${TEAM_LOGOS_URL}${info.logoPath}`}
+          alt={info.slug}
+          width={32}
+          height={32}
+          className="rounded-sm w-8 h-8"
+        />
+      ) : (
+        <span className="w-8 h-8 rounded-sm bg-vdcBlack/30" />
+      )}
+      <h2 className="text-sm">{info?.slug ?? "TBD"}</h2>
+    </span>
+  );
+}

--- a/components/player/agents/HeroAgentCard.tsx
+++ b/components/player/agents/HeroAgentCard.tsx
@@ -1,0 +1,126 @@
+import Image from "next/image";
+import { GameType } from "@prisma/client";
+import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import type { TeamLogoMap } from "@/lib/queries/teams/teams";
+import BestGameCard from "./BestGameCard";
+import PerSidePanel from "./PerSidePanel";
+
+type Props = {
+  entry: PlayerAgentBreakdown;
+  teamMap: TeamLogoMap;
+  gameType: GameType;
+};
+
+export default function HeroAgentCard({ entry, teamMap, gameType }: Props) {
+  const { catalog, averages, totals, gamesPlayed, wins, rounds } = entry;
+  const rating = (averages.ratingAttack + averages.ratingDefense) / 2;
+  const winPct = gamesPlayed === 0 ? 0 : (wins / gamesPlayed) * 100;
+  const kd = totals.deaths === 0 ? totals.kills : totals.kills / totals.deaths;
+  const adr = rounds === 0 ? 0 : totals.damage / rounds;
+  const fkPct = rounds === 0 ? 0 : (totals.firstKills / rounds) * 100;
+  const fdPct = rounds === 0 ? 0 : (totals.firstDeaths / rounds) * 100;
+
+  const stats: Array<[string, string]> = [
+    ["ACS", averages.acs.toFixed(0)],
+    ["ADR", adr.toFixed(0)],
+    ["K/D", kd.toFixed(2)],
+    ["KAST", `${averages.kast.toFixed(0)}%`],
+    ["HS%", `${averages.hsPercent.toFixed(0)}%`],
+    ["FK%", `${fkPct.toFixed(0)}%`],
+    ["FD%", `${fdPct.toFixed(0)}%`],
+    ["CLUT", String(totals.clutches)],
+  ];
+
+  const showBestGame = gameType !== GameType.COMBINE && entry.bestGame !== null;
+
+  const gradientStops = (catalog?.backgroundGradientColors ?? []).map(
+    (c) => `#${c.slice(0, 6)}`,
+  );
+  const gradientStyle =
+    gradientStops.length >= 2
+      ? { background: `linear-gradient(135deg, ${gradientStops.join(", ")})` }
+      : undefined;
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-md bg-slate-100 dark:bg-vdcGrey min-h-[220px] mx-2 xl:mx-0"
+      style={gradientStyle}
+    >
+      {catalog?.fullPortraitUrl && (
+        <Image
+          src={catalog.fullPortraitUrl}
+          alt={catalog.displayName}
+          fill
+          sizes="(min-width: 1280px) 768px, 100vw"
+          className="absolute pointer-events-none inset-0 object-cover object-[right_25%] brightness-50 dark:brightness-35 scale-110 origin-top-right translate-x-[30%]"
+        />
+      )}
+      <div className="absolute inset-0 pointer-events-none bg-linear-to-r from-vdcWhite/95 via-vdcWhite/60 to-transparent dark:from-vdcBlack/95 dark:via-vdcBlack/60" />
+
+      <div className="relative z-10 flex flex-col gap-3 p-4 xl:p-6">
+        <div className="grid grid-cols-1 xl:grid-cols-[1.2fr_2.5fr] gap-4 items-center">
+          <div className="flex items-center gap-3">
+            {catalog?.displayIconUrl && (
+              <Image
+                src={catalog.displayIconUrl}
+                alt={catalog.displayName}
+                width={200}
+                height={200}
+                className="rounded-md size-16"
+              />
+            )}
+            <div className="flex flex-col">
+              <h1 className="text-[10px] tracking-wider text-vdcBlack dark:text-gray-400">
+                Viewing
+              </h1>
+              <div className="flex items-center gap-2">
+                <h2 className="text-xl font-bold text-vdcBlack dark:text-vdcWhite leading-tight">
+                  {catalog?.displayName ?? entry.agent}
+                </h2>
+                {catalog?.role && (
+                  <>
+                    <Image
+                      src={catalog.role.iconUrl}
+                      alt={catalog.role.name}
+                      width={18}
+                      height={18}
+                      className="w-[18px] h-[18px] invert dark:invert-0"
+                    />
+                  </>
+                )}
+              </div>
+              <h2 className="text-[11px] font-normal text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                <span className="font-semibold text-vdcBlack dark:text-vdcWhite">
+                  {rating.toFixed(2)}
+                </span>{" "}
+                Rating &middot; {gamesPlayed} Games &middot; {winPct.toFixed(0)}
+                % WR
+              </h2>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 xl:grid-cols-4 gap-2">
+            {stats.map(([label, value]) => (
+              <div
+                key={label}
+                className="flex items-center justify-between rounded bg-slate-100/40 dark:bg-vdcBlack/40 backdrop-blur-sm px-2 py-1 text-xs"
+              >
+                <h1 className="text-vdcRed font-semibold">{label}</h1>
+                <h1 className="text-vdcBlack dark:text-vdcWhite">{value}</h1>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className={`grid gap-3 ${showBestGame ? "xl:grid-cols-[1.4fr_1fr]" : "xl:grid-cols-1"}`}
+        >
+          <PerSidePanel entry={entry} />
+          {showBestGame && entry.bestGame && (
+            <BestGameCard ref_={entry.bestGame} teamMap={teamMap} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/player/agents/NoAgentStats.tsx
+++ b/components/player/agents/NoAgentStats.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import type { BestGameRef } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import type { TeamLogoMap } from "@/lib/queries/teams/teams";
+import BestGameCard from "./BestGameCard";
+
+type Props = {
+  variant: "empty" | "season-empty-has-combine" | "combine-empty-has-season";
+  currentPlayerHref: string;
+  searchParams: Record<string, string | string[] | undefined>;
+  bestCombineGame?: BestGameRef | null;
+  teamMap?: TeamLogoMap;
+};
+
+function buildHrefWithType(
+  base: string,
+  searchParams: Props["searchParams"],
+  newType: "season" | "combine",
+): string {
+  const next = new URLSearchParams();
+  for (const [k, v] of Object.entries(searchParams)) {
+    if (typeof v === "string") next.set(k, v);
+  }
+  next.set("type", newType);
+  return `${base}?${next.toString()}`;
+}
+
+export default function NoAgentStats({
+  variant,
+  currentPlayerHref,
+  searchParams,
+  bestCombineGame,
+  teamMap,
+}: Props) {
+  if (variant === "empty") {
+    return (
+      <div className="m-auto text-center py-10">
+        <h1 className="text-vdcRed">
+          Player has no agent stats for this season.
+        </h1>
+      </div>
+    );
+  }
+
+  if (variant === "season-empty-has-combine") {
+    const tryCombineHref = buildHrefWithType(currentPlayerHref, searchParams, "combine");
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 px-2 xl:px-0">
+        <div className="text-center">
+          <h1 className="text-vdcRed">
+            Player has no agent stats for this season.
+          </h1>
+          <Link
+            href={tryCombineHref}
+            className="text-sm text-vdcBlack dark:text-vdcWhite underline hover:text-vdcRed"
+          >
+            Try combine instead
+          </Link>
+        </div>
+        {bestCombineGame && teamMap && (
+          <div className="w-full max-w-md">
+            <BestGameCard
+              ref_={bestCombineGame}
+              teamMap={teamMap}
+              variant="standalone"
+              label="Best combine game"
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const trySeasonHref = buildHrefWithType(currentPlayerHref, searchParams, "season");
+  return (
+    <div className="m-auto text-center py-10">
+      <h1 className="text-vdcRed">
+        Player has no agent stats for this combine.
+      </h1>
+      <Link
+        href={trySeasonHref}
+        className="text-sm text-vdcBlack dark:text-vdcWhite underline hover:text-vdcRed"
+      >
+        Try season instead
+      </Link>
+    </div>
+  );
+}

--- a/components/player/agents/PerSidePanel.tsx
+++ b/components/player/agents/PerSidePanel.tsx
@@ -1,0 +1,78 @@
+import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+
+type Props = { entry: PlayerAgentBreakdown; variant?: "hero" | "standalone" };
+
+export default function PerSidePanel({ entry, variant = "hero" }: Props) {
+  const { averages, rounds, roundsWon } = entry;
+  const roundsLost = rounds - roundsWon;
+  const roundWinPct = rounds === 0 ? 0 : (roundsWon / rounds) * 100;
+
+  const containerClasses =
+    variant === "hero"
+      ? "rounded-md bg-slate-100/40 dark:bg-vdcBlack/40 backdrop-blur-sm border border-black/5 dark:border-white/5 p-3"
+      : "rounded-md bg-slate-100 dark:bg-vdcGrey p-4";
+
+  return (
+    <div className={containerClasses}>
+      <h1 className="text-xs uppercase tracking-wider text-vdcBlack dark:text-gray-400 mb-3">
+        Per-side performance
+      </h1>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-4 ">
+        <BigCell
+          label="Attack"
+          value={averages.ratingAttack.toFixed(2)}
+          color="text-vdcRed"
+        />
+        <BigCell
+          label="Defense"
+          value={averages.ratingDefense.toFixed(2)}
+          color="text-vdcBlue"
+        />
+        <SmallCell
+          label="Rounds W-L"
+          value={`${roundsWon}-${roundsLost}`}
+        />
+        <SmallCell
+          label="Round W%"
+          value={`${roundWinPct.toFixed(0)}%`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BigCell({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div className="flex flex-col">
+      <h1 className="text-xs tracking-wider text-vdcBlack dark:text-gray-400 mb-1">
+        {label}
+      </h1>
+      <h2
+        className={`text-3xl font-bold leading-none ${color ?? "text-vdcBlack dark:text-vdcWhite"}`}
+      >
+        {value}
+      </h2>
+    </div>
+  );
+}
+
+function SmallCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <h1 className="text-xs tracking-wider text-vdcBlack dark:text-gray-400 mb-1">
+        {label}
+      </h1>
+      <h2 className="text-lg text-vdcBlack dark:text-vdcWhite tabular-nums">
+        {value}
+      </h2>
+    </div>
+  );
+}

--- a/components/player/agents/PerSidePanel.tsx
+++ b/components/player/agents/PerSidePanel.tsx
@@ -2,6 +2,13 @@ import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBre
 
 type Props = { entry: PlayerAgentBreakdown; variant?: "hero" | "standalone" };
 
+type CellDef = {
+  label: string;
+  value: string;
+  size: "big" | "small";
+  color?: string;
+};
+
 export default function PerSidePanel({ entry, variant = "hero" }: Props) {
   const { averages, rounds, roundsWon } = entry;
   const roundsLost = rounds - roundsWon;
@@ -12,67 +19,56 @@ export default function PerSidePanel({ entry, variant = "hero" }: Props) {
       ? "rounded-md bg-slate-100/40 dark:bg-vdcBlack/40 backdrop-blur-sm border border-black/5 dark:border-white/5 p-3"
       : "rounded-md bg-slate-100 dark:bg-vdcGrey p-4";
 
+  const cells: CellDef[] = [
+    {
+      label: "Attack",
+      value: averages.ratingAttack.toFixed(2),
+      size: "big",
+      color: "text-vdcRed",
+    },
+    {
+      label: "Defense",
+      value: averages.ratingDefense.toFixed(2),
+      size: "big",
+      color: "text-vdcBlue",
+    },
+    {
+      label: "Rounds W-L",
+      value: `${roundsWon}-${roundsLost}`,
+      size: "small",
+    },
+    {
+      label: "Round W%",
+      value: `${roundWinPct.toFixed(0)}%`,
+      size: "small",
+    },
+  ];
+
   return (
     <div className={containerClasses}>
       <h1 className="text-xs uppercase tracking-wider text-vdcBlack dark:text-gray-400 mb-3">
         Per-side performance
       </h1>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-4 ">
-        <BigCell
-          label="Attack"
-          value={averages.ratingAttack.toFixed(2)}
-          color="text-vdcRed"
-        />
-        <BigCell
-          label="Defense"
-          value={averages.ratingDefense.toFixed(2)}
-          color="text-vdcBlue"
-        />
-        <SmallCell
-          label="Rounds W-L"
-          value={`${roundsWon}-${roundsLost}`}
-        />
-        <SmallCell
-          label="Round W%"
-          value={`${roundWinPct.toFixed(0)}%`}
-        />
+      <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+        {cells.map((cell) => (
+          <Cell key={cell.label} {...cell} />
+        ))}
       </div>
     </div>
   );
 }
 
-function BigCell({
-  label,
-  value,
-  color,
-}: {
-  label: string;
-  value: string;
-  color?: string;
-}) {
+function Cell({ label, value, size, color }: CellDef) {
+  const valueClasses =
+    size === "big"
+      ? `text-3xl font-bold leading-none ${color ?? "text-vdcBlack dark:text-vdcWhite"}`
+      : "text-lg text-vdcBlack dark:text-vdcWhite tabular-nums";
   return (
     <div className="flex flex-col">
       <h1 className="text-xs tracking-wider text-vdcBlack dark:text-gray-400 mb-1">
         {label}
       </h1>
-      <h2
-        className={`text-3xl font-bold leading-none ${color ?? "text-vdcBlack dark:text-vdcWhite"}`}
-      >
-        {value}
-      </h2>
-    </div>
-  );
-}
-
-function SmallCell({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex flex-col">
-      <h1 className="text-xs tracking-wider text-vdcBlack dark:text-gray-400 mb-1">
-        {label}
-      </h1>
-      <h2 className="text-lg text-vdcBlack dark:text-vdcWhite tabular-nums">
-        {value}
-      </h2>
+      <h2 className={valueClasses}>{value}</h2>
     </div>
   );
 }

--- a/components/player/agents/PlayerAgents.tsx
+++ b/components/player/agents/PlayerAgents.tsx
@@ -1,0 +1,41 @@
+import { GameType } from "@prisma/client";
+import CombineDisclaimer from "@/components/player/CombineDisclaimer";
+import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import type { TeamLogoMap } from "@/lib/queries/teams/teams";
+import AgentTable from "./AgentTable";
+import HeroAgentCard from "./HeroAgentCard";
+import RoleDistribution from "./RoleDistribution";
+
+type Props = {
+  breakdown: PlayerAgentBreakdown[];
+  selected: PlayerAgentBreakdown;
+  selectedSlug: string;
+  gameType: GameType;
+  teamMap: TeamLogoMap;
+  basePath: string;
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+export default function PlayerAgents({
+  breakdown,
+  selected,
+  selectedSlug,
+  gameType,
+  teamMap,
+  basePath,
+  searchParams,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-3">
+      {gameType === GameType.COMBINE && <CombineDisclaimer />}
+      <RoleDistribution breakdown={breakdown} />
+      <HeroAgentCard entry={selected} teamMap={teamMap} gameType={gameType} />
+      <AgentTable
+        rows={breakdown}
+        selectedSlug={selectedSlug}
+        basePath={basePath}
+        searchParams={searchParams}
+      />
+    </div>
+  );
+}

--- a/components/player/agents/PlayerAgentsLoader.tsx
+++ b/components/player/agents/PlayerAgentsLoader.tsx
@@ -1,0 +1,129 @@
+import { GameType } from "@prisma/client";
+import { agentToUrlSlug } from "@/lib/common/agents";
+import { getAgentCatalog } from "@/lib/queries/agents/getAgentCatalog";
+import {
+  getPlayerAgentBreakdown,
+  type BestGameRef,
+  type PlayerAgentBreakdown,
+} from "@/lib/queries/stats/getPlayerAgentBreakdown";
+import { getTeamLogoMap } from "@/lib/queries/teams/teams";
+import NoAgentStats from "./NoAgentStats";
+import PlayerAgents from "./PlayerAgents";
+
+type Props = {
+  riotIGN: string;
+  season: number;
+  gameType: GameType;
+  basePath: string;
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+function pickBestAcrossEntries(entries: PlayerAgentBreakdown[]): BestGameRef | null {
+  let best: BestGameRef | null = null;
+  for (const e of entries) {
+    if (!e.bestGame) continue;
+    if (
+      best === null ||
+      e.bestGame.acs > best.acs ||
+      (e.bestGame.acs === best.acs && e.bestGame.kills > best.kills)
+    ) {
+      best = e.bestGame;
+    }
+  }
+  return best;
+}
+
+function collectTeamIds(refs: Array<BestGameRef | null | undefined>): number[] {
+  const ids = new Set<number>();
+  for (const r of refs) {
+    if (!r) continue;
+    if (r.home !== null) ids.add(r.home);
+    if (r.away !== null) ids.add(r.away);
+  }
+  return Array.from(ids);
+}
+
+export default async function PlayerAgentsLoader({
+  riotIGN,
+  season,
+  gameType,
+  basePath,
+  searchParams,
+}: Props) {
+  const catalog = await getAgentCatalog();
+  const breakdown = await getPlayerAgentBreakdown({
+    riotIgn: riotIGN,
+    season,
+    gameType,
+    catalog,
+  });
+
+  if (breakdown.length === 0) {
+    const inverse =
+      gameType === GameType.SEASON ? GameType.COMBINE : GameType.SEASON;
+    const fallback = await getPlayerAgentBreakdown({
+      riotIgn: riotIGN,
+      season,
+      gameType: inverse,
+      catalog,
+    });
+
+    if (fallback.length === 0) {
+      return (
+        <NoAgentStats
+          variant="empty"
+          currentPlayerHref={basePath}
+          searchParams={searchParams}
+        />
+      );
+    }
+
+    if (gameType === GameType.SEASON) {
+      const bestCombineGame = pickBestAcrossEntries(fallback);
+      const teamMap = await getTeamLogoMap(collectTeamIds([bestCombineGame]));
+      return (
+        <NoAgentStats
+          variant="season-empty-has-combine"
+          currentPlayerHref={basePath}
+          searchParams={searchParams}
+          bestCombineGame={bestCombineGame}
+          teamMap={teamMap}
+        />
+      );
+    }
+
+    return (
+      <NoAgentStats
+        variant="combine-empty-has-season"
+        currentPlayerHref={basePath}
+        searchParams={searchParams}
+      />
+    );
+  }
+
+  const mostPlayed = breakdown[0];
+  const requestedSlug =
+    typeof searchParams.agent === "string" ? searchParams.agent : undefined;
+  const selected =
+    breakdown.find(
+      (e) => agentToUrlSlug(e.catalog?.displayName ?? e.agent) === requestedSlug,
+    ) ?? mostPlayed;
+  const selectedSlug = agentToUrlSlug(
+    selected.catalog?.displayName ?? selected.agent,
+  );
+
+  const teamIds = collectTeamIds(breakdown.map((e) => e.bestGame));
+  const teamMap = await getTeamLogoMap(teamIds);
+
+  return (
+    <PlayerAgents
+      breakdown={breakdown}
+      selected={selected}
+      selectedSlug={selectedSlug}
+      gameType={gameType}
+      teamMap={teamMap}
+      basePath={basePath}
+      searchParams={searchParams}
+    />
+  );
+}

--- a/components/player/agents/PlayerAgentsSkeleton.tsx
+++ b/components/player/agents/PlayerAgentsSkeleton.tsx
@@ -1,0 +1,13 @@
+export default function PlayerAgentsSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 px-2 xl:px-0">
+      <div className="h-10 rounded-md bg-slate-100 dark:bg-vdcGrey animate-pulse" />
+      <div className="h-[220px] rounded-md bg-slate-100 dark:bg-vdcGrey animate-pulse" />
+      <div className="rounded-md bg-slate-100 dark:bg-vdcGrey p-4 flex flex-col gap-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-8 bg-slate-200 dark:bg-vdcBlack/40 rounded animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/player/agents/RoleDistribution.tsx
+++ b/components/player/agents/RoleDistribution.tsx
@@ -1,0 +1,84 @@
+import Image from "next/image";
+import { ROLE_HEX_COLOR_MAP, type RoleName } from "@/lib/common/constants";
+import type { PlayerAgentBreakdown } from "@/lib/queries/stats/getPlayerAgentBreakdown";
+
+type Props = { breakdown: PlayerAgentBreakdown[] };
+
+const ROLE_ORDER: RoleName[] = [
+  "DUELIST",
+  "CONTROLLER",
+  "SENTINEL",
+  "INITIATOR",
+];
+
+export default function RoleDistribution({ breakdown }: Props) {
+  const totals: Record<RoleName, number> = {
+    DUELIST: 0,
+    CONTROLLER: 0,
+    SENTINEL: 0,
+    INITIATOR: 0,
+  };
+  const iconUrls: Record<RoleName, string | null> = {
+    DUELIST: null,
+    CONTROLLER: null,
+    SENTINEL: null,
+    INITIATOR: null,
+  };
+  let known = 0;
+  for (const entry of breakdown) {
+    if (!entry.catalog?.role) continue;
+    const role = entry.catalog.role.name;
+    totals[role] += entry.gamesPlayed;
+    known += entry.gamesPlayed;
+    if (!iconUrls[role]) iconUrls[role] = entry.catalog.role.iconUrl;
+  }
+  if (known === 0) return null;
+
+  return (
+    <div className="bg-slate-100 dark:bg-vdcGrey rounded-md p-3 mx-2 xl:mx-0">
+      <h2 className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+        Roles played
+      </h2>
+      <div className="flex h-2 rounded overflow-hidden mb-2">
+        {ROLE_ORDER.map((role) => {
+          const pct = (totals[role] / known) * 100;
+          if (pct === 0) return null;
+          return (
+            <div
+              key={role}
+              style={{ width: `${pct}%`, background: ROLE_HEX_COLOR_MAP[role] }}
+            />
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+        {ROLE_ORDER.map((role) => {
+          const pct = (totals[role] / known) * 100;
+          if (pct === 0) return null;
+          const iconUrl = iconUrls[role];
+          return (
+            <span key={role} className="flex items-center gap-1">
+              {iconUrl ? (
+                <Image
+                  src={iconUrl}
+                  alt={role}
+                  width={16}
+                  height={16}
+                  className="w-4 h-4 invert dark:invert-0"
+                />
+              ) : (
+                <span
+                  className="inline-block w-2 h-2 rounded-sm"
+                  style={{ background: ROLE_HEX_COLOR_MAP[role] }}
+                />
+              )}
+              <h1 className="text-vdcBlack dark:text-vdcWhite">
+                {pct.toFixed(0)}%
+              </h1>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/player/summary/PlayerSummary.tsx
+++ b/components/player/summary/PlayerSummary.tsx
@@ -1,5 +1,4 @@
 import { GameType, Prisma } from "@prisma/client";
-import { InformationCircleIcon } from "@heroicons/react/16/solid";
 import PlayerRating from "./PlayerRating";
 import { PlayerStats } from "./PlayerStats";
 import PlayerMatches from "./PlayerMatches";
@@ -7,6 +6,7 @@ import {
   getTeamLogoMap,
   type TeamLogoMap,
 } from "@/lib/queries/teams/teams";
+import CombineDisclaimer from "@/components/player/CombineDisclaimer";
 
 export type StatsPayload = Prisma.PlayerStatsGetPayload<{
   include: { Game: { include: { Match: true } } };
@@ -66,27 +66,6 @@ async function buildTeamMap(stats: StatsPayload[]) {
     if (typeof away === "number") teamIds.push(away);
   }
   return getTeamLogoMap(teamIds);
-}
-
-function CombineDisclaimer() {
-  return (
-    <div className="rounded-md bg-vdcRed/30 dark:bg-vdcRed/10 p-4 mx-2 xl:mx-0 outline outline-vdcRed/20">
-      <div className="flex">
-        <div className="shrink-0">
-          <InformationCircleIcon
-            aria-hidden="true"
-            className="size-5 text-vdcRed"
-          />
-        </div>
-        <div className="ml-3 flex-1 md:flex md:justify-between">
-          <p className="text-sm text-vdcBlack dark:text-vdcWhite font-roboto italic">
-            Combine stats are stored differently than regular season stats. Some
-            data might be different or missing entirely.
-          </p>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function NoStats() {

--- a/lib/common/agents.ts
+++ b/lib/common/agents.ts
@@ -1,0 +1,8 @@
+export function normalizeAgentName(raw: string): string {
+  if (raw === "KAYO") return "KAY/O";
+  return raw.toUpperCase();
+}
+
+export function agentToUrlSlug(displayName: string): string {
+  return displayName.toLowerCase().replace(/[^a-z0-9]/g, "");
+}

--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -20,6 +20,7 @@ export const VDC_BLUE = "#3498db";
 export const VDC_GREEN = "#2ecc71";
 export const VDC_YELLOW = "#f1c40f";
 export const VDC_ORANGE = "#FF9266";
+export const VDC_RED = "#de3845";
 
 export const TIER_HEX_COLOR_MAP: Record<Tier, string> = {
   MYTHIC: VDC_PURPLE,
@@ -177,3 +178,19 @@ export const ROLES = Object.entries(Roles)
     label,
     value: BigInt(value as unknown as string),
   }));
+
+export type RoleName = "DUELIST" | "SENTINEL" | "CONTROLLER" | "INITIATOR";
+
+export const ROLE_COLOR_MAP: Record<RoleName, string> = {
+  DUELIST: "vdcRed",
+  CONTROLLER: "vdcBlue",
+  SENTINEL: "vdcGreen",
+  INITIATOR: "vdcOrange",
+};
+
+export const ROLE_HEX_COLOR_MAP: Record<RoleName, string> = {
+  DUELIST: VDC_RED,
+  CONTROLLER: VDC_BLUE,
+  SENTINEL: VDC_GREEN,
+  INITIATOR: VDC_ORANGE,
+};

--- a/lib/queries/agents/getAgentCatalog.ts
+++ b/lib/queries/agents/getAgentCatalog.ts
@@ -31,24 +31,20 @@ const ROLE_NAME_MAP: Record<string, RoleName> = {
   Initiator: "INITIATOR",
 };
 
-function toCatalogEntry(agent: ApiAgent): [string, AgentCatalogEntry] {
-  const normalized = normalizeAgentName(agent.displayName.toUpperCase());
+function toCatalogEntry(agent: ApiAgent): AgentCatalogEntry {
   const roleName = agent.role ? ROLE_NAME_MAP[agent.role.displayName] : undefined;
-  return [
-    normalized,
-    {
-      uuid: agent.uuid,
-      displayName: agent.displayName,
-      displayIconUrl: agent.displayIcon ?? "",
-      fullPortraitUrl: agent.fullPortrait ?? "",
-      isFullPortraitRightFacing: agent.isFullPortraitRightFacing,
-      backgroundGradientColors: agent.backgroundGradientColors ?? [],
-      role:
-        agent.role && roleName && agent.role.displayIcon
-          ? { uuid: agent.role.uuid, name: roleName, iconUrl: agent.role.displayIcon }
-          : null,
-    },
-  ];
+  return {
+    uuid: agent.uuid,
+    displayName: agent.displayName,
+    displayIconUrl: agent.displayIcon ?? "",
+    fullPortraitUrl: agent.fullPortrait ?? "",
+    isFullPortraitRightFacing: agent.isFullPortraitRightFacing,
+    backgroundGradientColors: agent.backgroundGradientColors ?? [],
+    role:
+      agent.role && roleName && agent.role.displayIcon
+        ? { uuid: agent.role.uuid, name: roleName, iconUrl: agent.role.displayIcon }
+        : null,
+  };
 }
 
 export const getAgentCatalog = cache(async (): Promise<AgentCatalog> => {
@@ -58,8 +54,14 @@ export const getAgentCatalog = cache(async (): Promise<AgentCatalog> => {
       { next: { revalidate: 86400 } },
     );
     if (!res.ok) return {};
+
     const json: { data: ApiAgent[] } = await res.json();
-    return Object.fromEntries(json.data.map(toCatalogEntry));
+    const catalog: AgentCatalog = {};
+    for (const agent of json.data) {
+      const key = normalizeAgentName(agent.displayName.toUpperCase());
+      catalog[key] = toCatalogEntry(agent);
+    }
+    return catalog;
   } catch {
     return {};
   }

--- a/lib/queries/agents/getAgentCatalog.ts
+++ b/lib/queries/agents/getAgentCatalog.ts
@@ -21,7 +21,11 @@ type ApiAgent = {
   fullPortrait: string | null;
   isFullPortraitRightFacing: boolean;
   backgroundGradientColors: string[] | null;
-  role: { uuid: string; displayName: string; displayIcon: string | null } | null;
+  role: {
+    uuid: string;
+    displayName: string;
+    displayIcon: string | null;
+  } | null;
 };
 
 const ROLE_NAME_MAP: Record<string, RoleName> = {
@@ -32,7 +36,9 @@ const ROLE_NAME_MAP: Record<string, RoleName> = {
 };
 
 function toCatalogEntry(agent: ApiAgent): AgentCatalogEntry {
-  const roleName = agent.role ? ROLE_NAME_MAP[agent.role.displayName] : undefined;
+  const roleName = agent.role
+    ? ROLE_NAME_MAP[agent.role.displayName]
+    : undefined;
   return {
     uuid: agent.uuid,
     displayName: agent.displayName,
@@ -42,7 +48,11 @@ function toCatalogEntry(agent: ApiAgent): AgentCatalogEntry {
     backgroundGradientColors: agent.backgroundGradientColors ?? [],
     role:
       agent.role && roleName && agent.role.displayIcon
-        ? { uuid: agent.role.uuid, name: roleName, iconUrl: agent.role.displayIcon }
+        ? {
+            uuid: agent.role.uuid,
+            name: roleName,
+            iconUrl: agent.role.displayIcon,
+          }
         : null,
   };
 }

--- a/lib/queries/agents/getAgentCatalog.ts
+++ b/lib/queries/agents/getAgentCatalog.ts
@@ -1,0 +1,66 @@
+import { cache } from "react";
+import { normalizeAgentName } from "@/lib/common/agents";
+import type { RoleName } from "@/lib/common/constants";
+
+export type AgentCatalogEntry = {
+  uuid: string;
+  displayName: string;
+  displayIconUrl: string;
+  fullPortraitUrl: string;
+  isFullPortraitRightFacing: boolean;
+  backgroundGradientColors: string[];
+  role: { uuid: string; name: RoleName; iconUrl: string } | null;
+};
+
+export type AgentCatalog = Record<string, AgentCatalogEntry>;
+
+type ApiAgent = {
+  uuid: string;
+  displayName: string;
+  displayIcon: string | null;
+  fullPortrait: string | null;
+  isFullPortraitRightFacing: boolean;
+  backgroundGradientColors: string[] | null;
+  role: { uuid: string; displayName: string; displayIcon: string | null } | null;
+};
+
+const ROLE_NAME_MAP: Record<string, RoleName> = {
+  Duelist: "DUELIST",
+  Sentinel: "SENTINEL",
+  Controller: "CONTROLLER",
+  Initiator: "INITIATOR",
+};
+
+function toCatalogEntry(agent: ApiAgent): [string, AgentCatalogEntry] {
+  const normalized = normalizeAgentName(agent.displayName.toUpperCase());
+  const roleName = agent.role ? ROLE_NAME_MAP[agent.role.displayName] : undefined;
+  return [
+    normalized,
+    {
+      uuid: agent.uuid,
+      displayName: agent.displayName,
+      displayIconUrl: agent.displayIcon ?? "",
+      fullPortraitUrl: agent.fullPortrait ?? "",
+      isFullPortraitRightFacing: agent.isFullPortraitRightFacing,
+      backgroundGradientColors: agent.backgroundGradientColors ?? [],
+      role:
+        agent.role && roleName && agent.role.displayIcon
+          ? { uuid: agent.role.uuid, name: roleName, iconUrl: agent.role.displayIcon }
+          : null,
+    },
+  ];
+}
+
+export const getAgentCatalog = cache(async (): Promise<AgentCatalog> => {
+  try {
+    const res = await fetch(
+      "https://valorant-api.com/v1/agents?isPlayableCharacter=true",
+      { next: { revalidate: 86400 } },
+    );
+    if (!res.ok) return {};
+    const json: { data: ApiAgent[] } = await res.json();
+    return Object.fromEntries(json.data.map(toCatalogEntry));
+  } catch {
+    return {};
+  }
+});

--- a/lib/queries/stats/getPlayerAgentBreakdown.ts
+++ b/lib/queries/stats/getPlayerAgentBreakdown.ts
@@ -1,0 +1,238 @@
+import { cache } from "react";
+import { GameType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { normalizeAgentName } from "@/lib/common/agents";
+import type {
+  AgentCatalog,
+  AgentCatalogEntry,
+} from "@/lib/queries/agents/getAgentCatalog";
+
+export type BestGameRef = {
+  gameID: string;
+  matchID: number;
+  map: string | null;
+  acs: number;
+  kills: number;
+  deaths: number;
+  playerTeamId: number | null;
+  home: number | null;
+  away: number | null;
+  homeRoundsWon: number;
+  awayRoundsWon: number;
+  datePlayed: Date;
+};
+
+export type PlayerAgentBreakdown = {
+  agent: string;
+  catalog: AgentCatalogEntry | null;
+  gamesPlayed: number;
+  wins: number;
+  rounds: number;
+  roundsWon: number;
+  totals: {
+    kills: number;
+    deaths: number;
+    assists: number;
+    firstKills: number;
+    firstDeaths: number;
+    clutches: number;
+    damage: number;
+  };
+  averages: {
+    acs: number;
+    kast: number;
+    hsPercent: number;
+    ratingAttack: number;
+    ratingDefense: number;
+  };
+  bestGame: BestGameRef | null;
+};
+
+type AccTotals = PlayerAgentBreakdown["totals"];
+type AccAverages = PlayerAgentBreakdown["averages"];
+
+type Accumulator = {
+  agent: string;
+  gamesPlayed: number;
+  wins: number;
+  rounds: number;
+  roundsWon: number;
+  totals: AccTotals;
+  averageSums: AccAverages;
+  averageCounts: Record<keyof AccAverages, number>;
+  bestGame: BestGameRef | null;
+};
+
+function emptyAccumulator(agent: string): Accumulator {
+  return {
+    agent,
+    gamesPlayed: 0,
+    wins: 0,
+    rounds: 0,
+    roundsWon: 0,
+    totals: {
+      kills: 0, deaths: 0, assists: 0,
+      firstKills: 0, firstDeaths: 0,
+      clutches: 0, damage: 0,
+    },
+    averageSums: {
+      acs: 0, kast: 0, hsPercent: 0,
+      ratingAttack: 0, ratingDefense: 0,
+    },
+    averageCounts: {
+      acs: 0, kast: 0, hsPercent: 0,
+      ratingAttack: 0, ratingDefense: 0,
+    },
+    bestGame: null,
+  };
+}
+
+function isBetterBest(candidate: BestGameRef, current: BestGameRef | null): boolean {
+  if (!current) return true;
+  if (candidate.acs !== current.acs) return candidate.acs > current.acs;
+  if (candidate.kills !== current.kills) return candidate.kills > current.kills;
+  return candidate.datePlayed > current.datePlayed;
+}
+
+export const getPlayerAgentBreakdown = cache(
+  async (args: {
+    riotIgn: string;
+    season: number;
+    gameType: GameType;
+    catalog: AgentCatalog;
+  }): Promise<PlayerAgentBreakdown[]> => {
+    const account = await prisma.account.findFirst({
+      where: { riotIGN: args.riotIgn },
+      select: { userId: true },
+    });
+    if (!account) return [];
+
+    const rows = await prisma.playerStats.findMany({
+      where: {
+        userID: account.userId,
+        Game: { season: args.season, gameType: args.gameType },
+      },
+      select: {
+        team: true,
+        agent: true,
+        kills: true,
+        deaths: true,
+        assists: true,
+        firstKills: true,
+        firstDeaths: true,
+        clutches: true,
+        damage: true,
+        acs: true,
+        kast: true,
+        hsPercent: true,
+        ratingAttack: true,
+        ratingDefense: true,
+        Game: {
+          select: {
+            gameID: true,
+            map: true,
+            winner: true,
+            rounds: true,
+            roundsWonHome: true,
+            roundsWonAway: true,
+            datePlayed: true,
+            Match: { select: { matchID: true, home: true, away: true } },
+          },
+        },
+      },
+    });
+
+    const byAgent = new Map<string, Accumulator>();
+
+    for (const r of rows) {
+      if (!r.agent) continue;
+      const agentKey = normalizeAgentName(r.agent);
+      const acc = byAgent.get(agentKey) ?? emptyAccumulator(agentKey);
+
+      acc.gamesPlayed += 1;
+      if (r.team !== null && r.team === r.Game.winner) acc.wins += 1;
+      acc.rounds += r.Game.rounds;
+      const playerWonRounds =
+        r.team !== null && r.Game.Match?.home === r.team
+          ? r.Game.roundsWonHome
+          : r.team !== null && r.Game.Match?.away === r.team
+          ? r.Game.roundsWonAway
+          : 0;
+      acc.roundsWon += playerWonRounds;
+
+      acc.totals.kills += r.kills ?? 0;
+      acc.totals.deaths += r.deaths ?? 0;
+      acc.totals.assists += r.assists ?? 0;
+      acc.totals.firstKills += r.firstKills ?? 0;
+      acc.totals.firstDeaths += r.firstDeaths ?? 0;
+      acc.totals.clutches += r.clutches ?? 0;
+      acc.totals.damage += r.damage ?? 0;
+
+      const addToAverage = (key: keyof AccAverages, value: number | null) => {
+        if (value === null) return;
+        acc.averageSums[key] += value;
+        acc.averageCounts[key] += 1;
+      };
+      addToAverage("acs", r.acs);
+      addToAverage("kast", r.kast);
+      addToAverage("hsPercent", r.hsPercent);
+      addToAverage("ratingAttack", r.ratingAttack);
+      addToAverage("ratingDefense", r.ratingDefense);
+
+      if (r.Game.Match && r.acs !== null) {
+        const candidate: BestGameRef = {
+          gameID: r.Game.gameID,
+          matchID: r.Game.Match.matchID,
+          map: r.Game.map,
+          acs: r.acs,
+          kills: r.kills ?? 0,
+          deaths: r.deaths ?? 0,
+          playerTeamId: r.team,
+          home: r.Game.Match.home,
+          away: r.Game.Match.away,
+          homeRoundsWon: r.Game.roundsWonHome,
+          awayRoundsWon: r.Game.roundsWonAway,
+          datePlayed: r.Game.datePlayed,
+        };
+        if (isBetterBest(candidate, acc.bestGame)) acc.bestGame = candidate;
+      }
+
+      byAgent.set(agentKey, acc);
+    }
+
+    const result: PlayerAgentBreakdown[] = [];
+    for (const acc of byAgent.values()) {
+      const mean = (sum: number, count: number) => (count === 0 ? 0 : sum / count);
+      result.push({
+        agent: acc.agent,
+        catalog: args.catalog[acc.agent] ?? null,
+        gamesPlayed: acc.gamesPlayed,
+        wins: acc.wins,
+        rounds: acc.rounds,
+        roundsWon: acc.roundsWon,
+        totals: acc.totals,
+        averages: {
+          acs: mean(acc.averageSums.acs, acc.averageCounts.acs),
+          kast: mean(acc.averageSums.kast, acc.averageCounts.kast),
+          hsPercent: mean(acc.averageSums.hsPercent, acc.averageCounts.hsPercent),
+          ratingAttack: mean(
+            acc.averageSums.ratingAttack,
+            acc.averageCounts.ratingAttack,
+          ),
+          ratingDefense: mean(
+            acc.averageSums.ratingDefense,
+            acc.averageCounts.ratingDefense,
+          ),
+        },
+        bestGame: acc.bestGame,
+      });
+    }
+
+    result.sort((a, b) => {
+      if (b.gamesPlayed !== a.gamesPlayed) return b.gamesPlayed - a.gamesPlayed;
+      return b.averages.acs - a.averages.acs;
+    });
+
+    return result;
+  },
+);

--- a/lib/queries/stats/stats.ts
+++ b/lib/queries/stats/stats.ts
@@ -1,6 +1,7 @@
 import { avg } from "@/lib/common/math";
 import { determineTierWithTierLines, getMMRTierLines } from "@/lib/common/tier";
 import { hasFlags } from "@/lib/common/flags";
+import { normalizeAgentName } from "@/lib/common/agents";
 import { prisma } from "@/lib/prisma";
 import { Flags } from "@/prisma";
 import { Tier, GameType } from "@prisma/client";
@@ -388,11 +389,7 @@ async function getAggregatedPlayerStatsByMatch(
         };
       }
       if (stat.agent) {
-        let normalizedAgent = stat.agent;
-        if (stat.agent === "KAYO") {
-          normalizedAgent = "KAY/O";
-        }
-        acc[u].agents.add(normalizedAgent);
+        acc[u].agents.add(normalizeAgentName(stat.agent));
       }
 
       Object.keys(acc[u]._sum).forEach((key) => {
@@ -475,13 +472,9 @@ export async function getPlayerStatsByGame(
     {};
 
   for (const { userID, agent, Team } of playerData) {
-    let normalizedAgent = agent;
-    if (agent === "KAYO") {
-      normalizedAgent = "KAY/O";
-    }
     if (!mergedMap[userID])
       mergedMap[userID] = { agents: [], team: Team?.name ?? null };
-    if (agent) mergedMap[userID].agents.push(normalizedAgent);
+    if (agent) mergedMap[userID].agents.push(normalizeAgentName(agent));
   }
 
   return groupedStats.map((stat) => ({


### PR DESCRIPTION
## Summary

Replaces the `<Soon />` placeholder in the player profile's Agents tab with a full per-agent breakdown. Adds dynamic agent metadata via the valorant-api.com catalog, OpenGraph link previews for the selected agent, and a sortable agent table modeled on the existing `StatsTable` styling.

## What's new (user-visible)

- **Hero card** for the selected agent: agent fullPortrait as the card background (with the agent's `backgroundGradientColors` as a 135deg tint), 4x2 stat grid (ACS · ADR · K/D · KAST · HS% · FK% · FD% · CLUT), per-side performance panel (Attack / Defense ratings + rounds W-L + round W%), and a best-game callout linking to the match page.
- **Role distribution bar** at the top with role icons + percentages.
- **Sortable table** of every agent the player has played (Agent · Games · WR · Rating · ACS · KD · ADR · KAST · HS%), with sticky first column, alternating-stripe-free design, hover row highlight, and click-to-swap navigation via `?agent=<slug>`.
- **Empty states** when the player has no stats: if on the season tab and combine games exist, the empty state hints at switching and renders the player's best combine match as a teaser; the reverse direction (combine empty → season has games) hints without the teaser.
- **CombineDisclaimer** banner appears on the Agents tab in combine mode, matching the Summary tab.
- **Light/dark theming** throughout: agent gradient + portrait both have theme-aware veil layers; transparent panels use `backdrop-blur` to keep text legible.
- **Link preview metadata** (`og:*` + `twitter:*`) — sharing `/player/<ign>?by=agents&agent=<slug>` into Discord/Slack/Twitter renders a `summary_large_image` card with the agent name, the player's rating/games/WR on that agent, and the agent's `fullPortrait` as the preview image. Falls back silently to the existing generic title when the agent slug is missing/invalid.

## Backend additions

- `lib/queries/agents/getAgentCatalog.ts` (new): fetches `https://valorant-api.com/v1/agents?isPlayableCharacter=true`, 24h Next data cache + per-request React `cache()`, maps each agent to `{ uuid, displayName, displayIconUrl, fullPortraitUrl, isFullPortraitRightFacing, backgroundGradientColors, role: { uuid, name, iconUrl } | null }`. Failure mode returns `{}` so the tab still renders without role badges.
- `lib/queries/stats/getPlayerAgentBreakdown.ts` (new): single `PlayerStats.findMany` filtered by `userID + season + gameType`, includes `Game.{rounds, roundsWonHome, roundsWonAway, winner, datePlayed, Match.{matchID, home, away}}`. Reduces in JS so we can normalize the agent name before grouping, compute win count from `team === Game.winner`, and track per-agent best-game by `(acs desc, kills desc, datePlayed desc)`.
- `lib/common/agents.ts` (new): `normalizeAgentName` (single source of truth for `KAYO -> KAY/O`) and `agentToUrlSlug` (lowercased displayName, non-alphanumerics stripped — handles `KAY/O -> kayo`).
- `lib/queries/stats/stats.ts`: two inline `KAYO -> KAY/O` blocks replaced by the shared helper.
- `lib/common/constants.ts`: adds `VDC_RED`, `RoleName` type, `ROLE_COLOR_MAP` (Tailwind tokens), `ROLE_HEX_COLOR_MAP` (hex for inline-style gradient bars).
- `components/player/CombineDisclaimer.tsx` (new): extracted from `PlayerSummary` so both tabs share one source.

## Notable design choices

- **Sort is client-only.** `?agent=<slug>` lives in the URL (shareable, deep-linkable, restored by the `og:` preview); table sort is `useState` inside `AgentTable` since it's ephemeral interaction, not navigation. Avoids a server round-trip per sort click.
- **Sticky first column uses opaque backgrounds in both states.** Selected rows get the red rail as an absolutely-positioned `<span>` inside the cell rather than a CSS border, because table-cell border rendering composes oddly with `position: sticky` and was making the rail slide during horizontal scroll.
- **Catalog is fetched dynamically rather than hardcoded** so new Riot releases flow in automatically (24h revalidation). Static fallback colors (`ROLE_HEX_COLOR_MAP`) handle the case where the API is reachable but a role's hex isn't.
- **OG metadata is wrapped in `try/catch`** with a fallback to the existing generic title so link unfurls never break the page on a query hiccup.

## Out of scope

- Per-side rounds W-L (the schema doesn't record starting side on `Games`, so only per-side rating is computable; overall rounds are shown).
- Caching `og:image` through our own CDN — currently hotlinks the valorant-api.com asset. Works today; worth revisiting if they rate-limit.

## Test plan

Run `pnpm dev` and verify each of the following on `/player/<ign>?season=<current>&type=season&by=agents`:

- [x] Golden path: role distribution bar appears, hero shows the most-played agent with portrait background + gradient, 8 stat chips, per-side panel + best-game card in the lower row, table beneath with all sort columns clickable.
- [x] Click any row → URL gains `?agent=<slug>`, hero swaps, red rail jumps to the new row.
- [x] Hover any row → entire row tints (gray light / dark gray); red row stays red on hover.
- [x] Sort each column → rows reorder, chevron moves, hero card unaffected.
- [x] Horizontal scroll on narrow viewport → agent column stays sticky and opaque (data behind doesn't show through); red rail stays glued to the sticky cell.
- [ ] Toggle to `?type=combine` → CombineDisclaimer banner appears, best-game card hides, per-side panel spans full width.
- [ ] Season tab on a combine-only player → "Try combine instead" hint + best-combine-game teaser card.
- [ ] Combine tab on a season-only player → "Try season instead" hint, no teaser card.
- [x] Player with zero stats anywhere → generic "no agent stats for this season" copy.
- [x] Bad slug (`?agent=notarealagent`) → silently defaults to most-played.
- [x] Mobile viewport (~375px) → role distribution stacks (title, bar, legend), hero collapses to single column with stat grid as 2-col, table scrolls horizontally with sticky agent column.
- [ ] `curl -s 'http://localhost:3000/player/<ign>?by=agents&agent=jett' | grep og:` shows `og:title`, `og:description`, `og:image` (valorant-api.com fullPortrait URL).
- [ ] Same URL minus the `agent` param → only the generic `<title>` is emitted, no `og:*` block.